### PR TITLE
Better error msg

### DIFF
--- a/src/plugins/uploader/smms.ts
+++ b/src/plugins/uploader/smms.ts
@@ -37,7 +37,7 @@ const handle = async (ctx: PicGo): Promise<PicGo> => {
     } else {
       ctx.emit('notification', {
         title: '上传失败！',
-        body: '当前网络状态不佳，请稍后再试'
+        body: body
       })
       throw new Error('Upload failed')
     }

--- a/src/plugins/uploader/smms.ts
+++ b/src/plugins/uploader/smms.ts
@@ -37,7 +37,7 @@ const handle = async (ctx: PicGo): Promise<PicGo> => {
     } else {
       ctx.emit('notification', {
         title: '上传失败！',
-        body: body
+        body: body.msg
       })
       throw new Error('Upload failed')
     }


### PR DESCRIPTION
Sometimes we may get other error, always give user the raw error msg is the best:

![image](https://user-images.githubusercontent.com/24741764/55451809-2199d400-5607-11e9-95d3-fb21f758e173.png)

PS: This error happens in vs-picgo when user select something invalid as filename. For example:

![image](https://user-images.githubusercontent.com/24741764/55451825-3d04df00-5607-11e9-9733-ce882c0dfee8.png)

