### PR TITLE
:bug: Fix: image_repeated error from smms

### DIFF
--- a/src/plugins/uploader/smms.ts
+++ b/src/plugins/uploader/smms.ts
@@ -34,6 +34,10 @@ const handle = async (ctx: PicGo): Promise<PicGo> => {
       delete imgList[i].base64Image
       delete imgList[i].buffer
       imgList[i]['imgUrl'] = body.data.url
+    } else if (body.code === 'image_repeated' && typeof body.images === 'string') { // do extra check since this error return is not documented at https://doc.sm.ms/#api-Image-Upload
+      delete imgList[i].base64Image
+      delete imgList[i].buffer
+      imgList[i]['imgUrl'] = body.images
     } else {
       ctx.emit('notification', {
         title: '上传失败',


### PR DESCRIPTION
silent and get real image url from image_repeated error from sm.ms

Still try to get image url from following error:

<img width="1413" alt="Screen Shot 2019-12-30 at 22 17 41" src="https://user-images.githubusercontent.com/1621242/71585631-3bdeef00-2b52-11ea-87fe-ddbb3530071e.png">
