### PR TITLE
:bug: Fix: win10 cmd crash bug when "picgo upload"

### DIFF
--- a/src/utils/clipboard/windows10.ps1
+++ b/src/utils/clipboard/windows10.ps1
@@ -27,6 +27,9 @@ function main {
     $stream.Dispose() | out-null
 
     $imagePath
+    # fix windows 10 native cmd crash bug when "picgo upload"
+    # https://github.com/PicGo/PicGo-Core/issues/32
+    Exit 1
 }
 
 try {

--- a/src/utils/getClipboardImage.ts
+++ b/src/utils/getClipboardImage.ts
@@ -46,10 +46,10 @@ const getClipboardImage = (ctx: PicGo): Promise<ClipboardImage> => {
         '-nologo',
         '-sta',
         '-executionpolicy', 'unrestricted',
-        // '-windowstyle', 'hidden',
-        // prevent powershell console from closing after running script 
+        // fix windows 10 native cmd crash bug when "picgo upload"
         // https://github.com/PicGo/PicGo-Core/issues/32
-        '-noexit',
+        // '-windowstyle', 'hidden',
+        // '-noexit',
         '-file', scriptPath,
         imagePath
       ])

--- a/src/utils/getClipboardImage.ts
+++ b/src/utils/getClipboardImage.ts
@@ -46,7 +46,10 @@ const getClipboardImage = (ctx: PicGo): Promise<ClipboardImage> => {
         '-nologo',
         '-sta',
         '-executionpolicy', 'unrestricted',
-        '-windowstyle', 'hidden',
+        // '-windowstyle', 'hidden',
+        // prevent powershell console from closing after running script 
+        // https://github.com/PicGo/PicGo-Core/issues/32
+        '-noexit',
         '-file', scriptPath,
         imagePath
       ])


### PR DESCRIPTION
[Issue 32 -- “picgo upload" to uplad the first image at clipboard will crash in Win 10](https://github.com/PicGo/PicGo-Core/issues/32)