### PR TITLE
:sparkles: Feature: support upload buffer

### DIFF
--- a/src/plugins/transformer/path.ts
+++ b/src/plugins/transformer/path.ts
@@ -10,7 +10,14 @@ const handle = async (ctx: IPicGo): Promise<IPicGo> => {
   const results: IImgInfo[] = ctx.output
   await Promise.all(ctx.input.map(async (item: string, index: number) => {
     let info: IPathTransformedImgInfo
-    if (isUrl(item)) {
+    if (Buffer.isBuffer(item)) {
+      info = {
+        success: true,
+        buffer: item,
+        fileName: 'temporary.png',
+        extname: '.png'
+      }
+    } else if (isUrl(item)) {
       info = await getURLFile(item, ctx)
     } else {
       info = await getFSFile(item)


### PR DESCRIPTION
In the API upload mode, hope to support upload buffter, but I'm not sure if only one image format is supported, such as .png