### PR TITLE
Fix: formatted buffer fileName with '}' suffix

### DIFF
--- a/src/plugins/transformer/path.ts
+++ b/src/plugins/transformer/path.ts
@@ -28,7 +28,7 @@ const handle = async (ctx: IPicGo): Promise<IPicGo> => {
       const extname = info.extname || imgSize.extname || '.png'
       results[index] = {
         buffer: info.buffer,
-        fileName: info.fileName || `${dayjs().format('YYYYMMDDHHmmss')}${extname}}`,
+        fileName: info.fileName || `${dayjs().format('YYYYMMDDHHmmss')}${extname}`,
         width: imgSize.width,
         height: imgSize.height,
         extname


### PR DESCRIPTION
When i upload a image buffer, i will get an error like this:
`[PicGo ERROR]: Error: No mime type found for file 20240103171520.png}`

Because the formated fileName with '}' suffix.

When i fix it by my custom plugin, i will upload buffer success.

![image](https://github.com/PicGo/PicGo-Core/assets/23397937/d3fb644c-ab8c-473a-bb0a-7a0d29a3e5f9)
