### PR TITLE
fix(cli): filters optional

### DIFF
--- a/src/utils/initUtils.ts
+++ b/src/utils/initUtils.ts
@@ -19,19 +19,21 @@ const generate = async (ctx: IPicGo, options: IOptions): Promise<any> => {
       answers = await ctx.cmd.inquirer.prompt(opts.prompts)
     }
     let _files: string[] = await globby(['**/*'], { cwd: source, dot: true }) // get files' name array
-    _files = _files.filter((item: string) => {
-      let glob = ''
-      Object.keys(opts.filters).forEach((key: string) => {
-        if (match(item, key, { dot: true })) {
-          glob = item
+
+    const filterKeys = Object.keys(opts.filters || {})
+    if (filterKeys.length > 0) {
+      _files = _files.filter((item: string) => {
+        let glob = ''
+        for (const key of filterKeys) {
+          if (match(item, key, { dot: true })) {
+            glob = item
+            break
+          }
         }
+        return glob ? filters(ctx, opts.filters[glob], answers) : true
       })
-      if (glob) { // find a filter expression
-        return filters(ctx, opts.filters[glob], answers)
-      } else {
-        return true
-      }
-    })
+    }
+
     if (_files.length === 0) {
       return ctx.log.warn('Template files not found!')
     }


### PR DESCRIPTION
修复以下报错

```
$ picgo init imba97/picgo-template-plugin-test picgo-template-plugin-test-1

[PicGo INFO]: Template files are downloading...
[PicGo SUCCESS]: Template files are downloaded!
? Plugin name: test   
? Plugin description: test plugin
? author: imba97    
? Github user/repo: imba97/picgo-plugin-test
[PicGo ERROR]: TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at C:\Users\imba97\AppData\Local\npm-cache\_npx\2376b2220af0d629\node_modules\picgo\dist\index.cjs.js:1:9435     
    at Array.filter (<anonymous>)
    at ye (C:\Users\imba97\AppData\Local\npm-cache\_npx\2376b2220af0d629\node_modules\picgo\dist\index.cjs.js:1:9400)
```

目前版本使用 `init` 初始化自定义模板时，如果模板没有定义 `filters` 会报错，原因是 `Object.keys(undefined)`

但看官方文档里说 `filters` 是可选的