### PR TITLE
:bug: Fix(plugin-handler): add optional `env` param for `uninstall` method

### DIFF
--- a/src/lib/PluginHandler.ts
+++ b/src/lib/PluginHandler.ts
@@ -101,13 +101,13 @@ export class PluginHandler implements IPluginHandler {
     }
   }
 
-  async uninstall (plugins: string[]): Promise<IPluginHandlerResult<boolean>> {
+  async uninstall (plugins: string[], env?: IProcessEnv): Promise<IPluginHandlerResult<boolean>> {
     const processPlugins = plugins.map((item: string) => handlePluginNameProcess(this.ctx, item)).filter(item => item.success)
     const pkgNameList = processPlugins.map(item => item.pkgName)
     if (pkgNameList.length > 0) {
       // uninstall plugins must use pkgNameList:
       // npm uninstall will use the package.json's name
-      const result = await this.execCommand('uninstall', pkgNameList, this.ctx.baseDir)
+      const result = await this.execCommand('uninstall', pkgNameList, this.ctx.baseDir, undefined, env)
       if (!result.code) {
         pkgNameList.forEach((pluginName: string) => {
           this.ctx.pluginLoader.unregisterPlugin(pluginName)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -559,7 +559,7 @@ export interface IPluginProcessResult {
 export interface IPluginHandler {
   install: (plugins: string[], options: IPluginHandlerOptions, env?: IProcessEnv) => Promise<IPluginHandlerResult<boolean>>
   update: (plugins: string[], options: IPluginHandlerOptions, env?: IProcessEnv) => Promise<IPluginHandlerResult<boolean>>
-  uninstall: (plugins: string[]) => Promise<IPluginHandlerResult<boolean>>
+  uninstall: (plugins: string[], env?: IProcessEnv) => Promise<IPluginHandlerResult<boolean>>
 }
 
 export interface IPluginHandlerResult<T> {


### PR DESCRIPTION
统一`pluginHandler`的`install`、`update`和`uninstalll`方法中的环境变量参数`env`，解决卸载插件的时候无法配置环境变量的问题。