### PR TITLE
:bug: Fix(core): 支持 Windows WSL 网络共享路径

### DIFF
--- a/src/__tests__/integration/uploadWslPath.spec.ts
+++ b/src/__tests__/integration/uploadWslPath.spec.ts
@@ -1,0 +1,95 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { PicGo } from '../../core/PicGo'
+import type { IPicGo } from '../../types'
+
+vi.mock('../../utils/getClipboardImage', () => ({
+  default: vi.fn()
+}))
+
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+)
+const FILE_NAME = 'integration-upload.png'
+
+const findWslDistro = (): string | undefined => {
+  if (process.platform !== 'win32') return undefined
+
+  try {
+    const output = execFileSync('wsl.exe', ['--list', '--quiet'], { encoding: 'utf8' })
+    return output
+      .replaceAll('\0', '')
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .find(line => line.length > 0)
+  } catch {
+    return undefined
+  }
+}
+
+const runInWsl = (distro: string, command: string): string => {
+  return execFileSync('wsl.exe', ['-d', distro, '--', 'sh', '-c', command], { encoding: 'utf8' }).trim()
+}
+
+const wslDistro = findWslDistro()
+
+describe.skipIf(wslDistro === undefined)('WSL network-share path upload integration', () => {
+  let configDir = ''
+  let uncDirPath = ''
+  let relativeWslPath = ''
+  const received: Array<{ fileName?: string, filePath?: string, buffer?: Buffer }> = []
+
+  beforeAll(() => {
+    if (wslDistro === undefined) return
+
+    configDir = mkdtempSync(path.join(tmpdir(), 'picgo-wsl-integration-'))
+    const linuxHome = runInWsl(wslDistro, 'printf %s "$HOME"')
+    const relativeHome = linuxHome.slice(1).replaceAll('/', '\\')
+    const relativeDir = `picgo-core-integration-${process.pid}`
+    uncDirPath = `\\\\wsl$\\${wslDistro}\\${relativeHome}\\${relativeDir}`
+    const uncFilePath = `${uncDirPath}\\${FILE_NAME}`
+    relativeWslPath = `wsl$\\${wslDistro}\\${relativeHome}\\${relativeDir}\\${FILE_NAME}`
+
+    mkdirSync(uncDirPath, { recursive: true })
+    writeFileSync(uncFilePath, PNG_BYTES)
+    expect(existsSync(uncFilePath)).toBe(true)
+    expect(existsSync(relativeWslPath)).toBe(false)
+  }, 60000)
+
+  afterAll(async () => {
+    await new Promise(resolve => setTimeout(resolve, 500))
+    if (uncDirPath !== '') rmSync(uncDirPath, { recursive: true, force: true })
+    if (configDir !== '') rmSync(configDir, { recursive: true, force: true })
+  }, 60000)
+
+  it('uploads a raw Typora-style WSL path through PicGo Core', async () => {
+    const picgo = new PicGo(path.join(configDir, 'config.json'))
+    picgo.saveConfig({ 'picBed.uploader': 'stub', debug: false })
+    picgo.helper.uploader.register('stub', {
+      name: 'Stub',
+      handle: async (ctx: IPicGo) => {
+        for (const item of ctx.output) {
+          item.imgUrl = `https://integration.example/${item.fileName ?? FILE_NAME}`
+          received.push({ fileName: item.fileName, filePath: item.filePath, buffer: item.buffer })
+        }
+      }
+    })
+
+    const result = await picgo.upload([relativeWslPath])
+
+    expect(received).toHaveLength(1)
+    expect(received[0].fileName).toBe(FILE_NAME)
+    expect(received[0].filePath).toMatch(/^\\\\wsl\$\\/i)
+    expect(received[0].buffer?.equals(PNG_BYTES)).toBe(true)
+    expect(result).toEqual([
+      expect.objectContaining({
+        origin: relativeWslPath,
+        imgUrl: `https://integration.example/${FILE_NAME}`
+      })
+    ])
+  }, 60000)
+})

--- a/src/__tests__/integration/uploadWslPath.spec.ts
+++ b/src/__tests__/integration/uploadWslPath.spec.ts
@@ -16,48 +16,40 @@ const PNG_BYTES = Buffer.from(
 )
 const FILE_NAME = 'integration-upload.png'
 
-const findWslDistro = (): string | undefined => {
+const findDefaultWslHome = (): string | undefined => {
   if (process.platform !== 'win32') return undefined
 
   try {
-    const output = execFileSync('wsl.exe', ['--list', '--quiet'], { encoding: 'utf8' })
-    return output
-      .replaceAll('\0', '')
-      .split(/\r?\n/)
-      .map(line => line.trim())
-      .find(line => line.length > 0)
+    const output = execFileSync('wsl.exe', ['--exec', 'sh', '-c', 'wslpath -w "$HOME"'], { encoding: 'utf8' })
+    const wslHome = output.replaceAll('\0', '').trim()
+    return /^\\\\wsl(?:\$|\.localhost)\\/i.test(wslHome) ? wslHome : undefined
   } catch {
     return undefined
   }
 }
 
-const runInWsl = (distro: string, command: string): string => {
-  return execFileSync('wsl.exe', ['-d', distro, '--', 'sh', '-c', command], { encoding: 'utf8' }).trim()
-}
+const defaultWslHome = findDefaultWslHome()
 
-const wslDistro = findWslDistro()
-
-describe.skipIf(wslDistro === undefined)('WSL network-share path upload integration', () => {
+describe.skipIf(defaultWslHome === undefined)('WSL network-share path upload integration', () => {
   let configDir = ''
   let uncDirPath = ''
   let relativeWslPath = ''
   const received: Array<{ fileName?: string, filePath?: string, buffer?: Buffer }> = []
 
   beforeAll(() => {
-    if (wslDistro === undefined) return
+    if (defaultWslHome === undefined) return
 
     configDir = mkdtempSync(path.join(tmpdir(), 'picgo-wsl-integration-'))
-    const linuxHome = runInWsl(wslDistro, 'printf %s "$HOME"')
-    const relativeHome = linuxHome.slice(1).replaceAll('/', '\\')
     const relativeDir = `picgo-core-integration-${process.pid}`
-    uncDirPath = `\\\\wsl$\\${wslDistro}\\${relativeHome}\\${relativeDir}`
-    const uncFilePath = `${uncDirPath}\\${FILE_NAME}`
-    relativeWslPath = `wsl$\\${wslDistro}\\${relativeHome}\\${relativeDir}\\${FILE_NAME}`
+    uncDirPath = path.win32.join(defaultWslHome, relativeDir)
+    const uncFilePath = path.win32.join(uncDirPath, FILE_NAME)
+    relativeWslPath = uncFilePath.replace(/^\\\\/, '')
 
     mkdirSync(uncDirPath, { recursive: true })
     writeFileSync(uncFilePath, PNG_BYTES)
     expect(existsSync(uncFilePath)).toBe(true)
     expect(existsSync(relativeWslPath)).toBe(false)
+    expect(relativeWslPath).toMatch(/^wsl(?:\$|\.localhost)\\/i)
   }, 60000)
 
   afterAll(async () => {
@@ -83,7 +75,7 @@ describe.skipIf(wslDistro === undefined)('WSL network-share path upload integrat
 
     expect(received).toHaveLength(1)
     expect(received[0].fileName).toBe(FILE_NAME)
-    expect(received[0].filePath).toMatch(/^\\\\wsl\$\\/i)
+    expect(received[0].filePath).toMatch(/^\\\\wsl(?:\$|\.localhost)\\/i)
     expect(received[0].buffer?.equals(PNG_BYTES)).toBe(true)
     expect(result).toEqual([
       expect.objectContaining({

--- a/src/__tests__/unit/commanderUpload.spec.ts
+++ b/src/__tests__/unit/commanderUpload.spec.ts
@@ -1,22 +1,13 @@
 import path from 'node:path'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { resolveUploadInput } from '../../plugins/commander/upload'
 
-const mocks = vi.hoisted(() => ({
-  normalizeWslPath: vi.fn()
-}))
-
-vi.mock('../../utils/normalizeWslPath', () => ({
-  normalizeWslPath: mocks.normalizeWslPath
-}))
-
-describe('commander upload input handling', () => {
-  it('normalizes WSL paths before resolving them', () => {
-    const inputPath = 'wsl$\\Ubuntu\\home\\user\\image.png'
-    const normalizedPath = '\\\\wsl$\\Ubuntu\\home\\user\\image.png'
-    mocks.normalizeWslPath.mockReturnValue(normalizedPath)
+describe.skipIf(process.platform !== 'win32')('commander upload input handling', () => {
+  it.each(['wsl$', 'wsl.localhost'])('normalizes %s paths before resolving them', (prefix) => {
+    const inputPath = `${prefix}\\TestDistro\\home\\user\\image.png`
+    const normalizedPath = `\\\\${inputPath}`
 
     expect(resolveUploadInput(inputPath)).toBe(path.resolve(normalizedPath))
-    expect(mocks.normalizeWslPath).toHaveBeenCalledWith(inputPath)
+    expect(resolveUploadInput(inputPath)).not.toBe(path.resolve(inputPath))
   })
 })

--- a/src/__tests__/unit/commanderUpload.spec.ts
+++ b/src/__tests__/unit/commanderUpload.spec.ts
@@ -1,0 +1,22 @@
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { resolveUploadInput } from '../../plugins/commander/upload'
+
+const mocks = vi.hoisted(() => ({
+  normalizeWslPath: vi.fn()
+}))
+
+vi.mock('../../utils/normalizeWslPath', () => ({
+  normalizeWslPath: mocks.normalizeWslPath
+}))
+
+describe('commander upload input handling', () => {
+  it('normalizes WSL paths before resolving them', () => {
+    const inputPath = 'wsl$\\Ubuntu\\home\\user\\image.png'
+    const normalizedPath = '\\\\wsl$\\Ubuntu\\home\\user\\image.png'
+    mocks.normalizeWslPath.mockReturnValue(normalizedPath)
+
+    expect(resolveUploadInput(inputPath)).toBe(path.resolve(normalizedPath))
+    expect(mocks.normalizeWslPath).toHaveBeenCalledWith(inputPath)
+  })
+})

--- a/src/__tests__/unit/getFSFile.spec.ts
+++ b/src/__tests__/unit/getFSFile.spec.ts
@@ -10,10 +10,10 @@ vi.mock('../../utils/normalizeWslPath', () => ({
   normalizeWslPath: mocks.normalizeWslPath
 }))
 
-describe('utils/getFSFile', () => {
+describe.skipIf(process.platform !== 'win32')('utils/getFSFile', () => {
   it('normalizes the path before reading while preserving file metadata', async () => {
-    const inputPath = 'wsl$\\Ubuntu\\home\\user\\image.png'
-    const normalizedPath = '\\\\wsl$\\Ubuntu\\home\\user\\image.png'
+    const inputPath = 'wsl$\\TestDistro\\home\\user\\image.png'
+    const normalizedPath = '\\\\wsl$\\TestDistro\\home\\user\\image.png'
     const buffer = Buffer.from('image')
     mocks.normalizeWslPath.mockReturnValue(normalizedPath)
     const readFileMock = vi.spyOn(fs, 'readFile').mockResolvedValue(buffer)

--- a/src/__tests__/unit/getFSFile.spec.ts
+++ b/src/__tests__/unit/getFSFile.spec.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getFSFile } from '../../utils/common'
 
 const mocks = vi.hoisted(() => ({
@@ -11,21 +11,32 @@ vi.mock('../../utils/normalizeWslPath', () => ({
 }))
 
 describe.skipIf(process.platform !== 'win32')('utils/getFSFile', () => {
-  it('normalizes the path before reading while preserving file metadata', async () => {
-    const inputPath = 'wsl$\\TestDistro\\home\\user\\image.png'
-    const normalizedPath = '\\\\wsl$\\TestDistro\\home\\user\\image.png'
-    const buffer = Buffer.from('image')
-    mocks.normalizeWslPath.mockReturnValue(normalizedPath)
-    const readFileMock = vi.spyOn(fs, 'readFile').mockResolvedValue(buffer)
-
-    await expect(getFSFile(inputPath)).resolves.toEqual({
-      extname: '.png',
-      fileName: 'image.png',
-      filePath: normalizedPath,
-      buffer,
-      success: true
-    })
-    expect(mocks.normalizeWslPath).toHaveBeenCalledWith(inputPath)
-    expect(readFileMock).toHaveBeenCalledWith(normalizedPath)
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each(['wsl$', 'wsl.localhost'])(
+    'normalizes the %s path before reading while preserving file metadata',
+    async (prefix) => {
+      const inputPath = `${prefix}\\TestDistro\\home\\user\\image.png`
+      const normalizedPath = `\\\\${inputPath}`
+      const buffer = Buffer.from('image')
+      mocks.normalizeWslPath.mockReturnValue(normalizedPath)
+      const readFileMock = vi.spyOn(fs, 'readFile').mockResolvedValue(buffer)
+
+      await expect(getFSFile(inputPath)).resolves.toEqual({
+        extname: '.png',
+        fileName: 'image.png',
+        filePath: normalizedPath,
+        buffer,
+        success: true
+      })
+      expect(mocks.normalizeWslPath).toHaveBeenCalledWith(inputPath)
+      expect(readFileMock).toHaveBeenCalledWith(normalizedPath)
+    }
+  )
 })

--- a/src/__tests__/unit/getFSFile.spec.ts
+++ b/src/__tests__/unit/getFSFile.spec.ts
@@ -1,0 +1,31 @@
+import fs from 'fs-extra'
+import { describe, expect, it, vi } from 'vitest'
+import { getFSFile } from '../../utils/common'
+
+const mocks = vi.hoisted(() => ({
+  normalizeWslPath: vi.fn()
+}))
+
+vi.mock('../../utils/normalizeWslPath', () => ({
+  normalizeWslPath: mocks.normalizeWslPath
+}))
+
+describe('utils/getFSFile', () => {
+  it('normalizes the path before reading while preserving file metadata', async () => {
+    const inputPath = 'wsl$\\Ubuntu\\home\\user\\image.png'
+    const normalizedPath = '\\\\wsl$\\Ubuntu\\home\\user\\image.png'
+    const buffer = Buffer.from('image')
+    mocks.normalizeWslPath.mockReturnValue(normalizedPath)
+    const readFileMock = vi.spyOn(fs, 'readFile').mockResolvedValue(buffer)
+
+    await expect(getFSFile(inputPath)).resolves.toEqual({
+      extname: '.png',
+      fileName: 'image.png',
+      filePath: normalizedPath,
+      buffer,
+      success: true
+    })
+    expect(mocks.normalizeWslPath).toHaveBeenCalledWith(inputPath)
+    expect(readFileMock).toHaveBeenCalledWith(normalizedPath)
+  })
+})

--- a/src/__tests__/unit/normalizeWslPath.spec.ts
+++ b/src/__tests__/unit/normalizeWslPath.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeWslPath } from '../../utils/normalizeWslPath'
+
+const WslPrefix = 'wsl$'
+const TestFileName = 'image.png'
+const TestDistributions = ['test-distribution', 'alternate-distribution']
+
+const createRelativeWslPath = (distribution: string, separator: '/' | '\\' = '\\'): string => {
+  return [WslPrefix, distribution, TestFileName].join(separator)
+}
+
+const createAbsoluteWslPath = (distribution: string): string => `\\\\${createRelativeWslPath(distribution)}`
+
+describe('utils/normalizeWslPath', () => {
+  it.each([
+    [createRelativeWslPath(TestDistributions[0]), createAbsoluteWslPath(TestDistributions[0])],
+    [createRelativeWslPath(TestDistributions[1], '/'), createAbsoluteWslPath(TestDistributions[1])],
+    [createRelativeWslPath(TestDistributions[0]).replaceAll('\\', '\\\\'), createAbsoluteWslPath(TestDistributions[0])]
+  ])('adds the UNC prefix to %s', (filePath, expectedPath) => {
+    expect(normalizeWslPath(filePath, 'win32')).toBe(expectedPath)
+  })
+
+  it('leaves an already absolute WSL UNC path unchanged', () => {
+    const filePath = createAbsoluteWslPath(TestDistributions[0])
+
+    expect(normalizeWslPath(filePath, 'win32')).toBe(filePath)
+  })
+
+  it('leaves non-WSL paths unchanged', () => {
+    const filePath = 'not-a-wsl-path'
+
+    expect(normalizeWslPath(filePath, 'win32')).toBe(filePath)
+  })
+
+  it('does not change WSL paths on non-Windows platforms', () => {
+    const filePath = createRelativeWslPath(TestDistributions[0])
+
+    expect(normalizeWslPath(filePath, 'linux')).toBe(filePath)
+  })
+})

--- a/src/__tests__/unit/normalizeWslPath.spec.ts
+++ b/src/__tests__/unit/normalizeWslPath.spec.ts
@@ -1,27 +1,32 @@
 import { describe, expect, it } from 'vitest'
 import { normalizeWslPath } from '../../utils/normalizeWslPath'
 
-const WslPrefix = 'wsl$'
+const WslPrefixes = ['wsl$', 'wsl.localhost']
 const TestFileName = 'image.png'
 const TestDistributions = ['test-distribution', 'alternate-distribution']
 
-const createRelativeWslPath = (distribution: string, separator: '/' | '\\' = '\\'): string => {
-  return [WslPrefix, distribution, TestFileName].join(separator)
+const createRelativeWslPath = (prefix: string, distribution: string, separator: '/' | '\\' = '\\'): string => {
+  return [prefix, distribution, TestFileName].join(separator)
 }
 
-const createAbsoluteWslPath = (distribution: string): string => `\\\\${createRelativeWslPath(distribution)}`
+const createAbsoluteWslPath = (prefix: string, distribution: string): string => {
+  return `\\\\${createRelativeWslPath(prefix, distribution)}`
+}
 
 describe('utils/normalizeWslPath', () => {
-  it.each([
-    [createRelativeWslPath(TestDistributions[0]), createAbsoluteWslPath(TestDistributions[0])],
-    [createRelativeWslPath(TestDistributions[1], '/'), createAbsoluteWslPath(TestDistributions[1])],
-    [createRelativeWslPath(TestDistributions[0]).replaceAll('\\', '\\\\'), createAbsoluteWslPath(TestDistributions[0])]
-  ])('adds the UNC prefix to %s', (filePath, expectedPath) => {
+  it.each(WslPrefixes.flatMap(prefix => [
+    [createRelativeWslPath(prefix, TestDistributions[0]), createAbsoluteWslPath(prefix, TestDistributions[0])],
+    [createRelativeWslPath(prefix, TestDistributions[1], '/'), createAbsoluteWslPath(prefix, TestDistributions[1])],
+    [
+      createRelativeWslPath(prefix, TestDistributions[0]).replaceAll('\\', '\\\\'),
+      createAbsoluteWslPath(prefix, TestDistributions[0])
+    ]
+  ]))('adds the UNC prefix to %s', (filePath, expectedPath) => {
     expect(normalizeWslPath(filePath, 'win32')).toBe(expectedPath)
   })
 
-  it('leaves an already absolute WSL UNC path unchanged', () => {
-    const filePath = createAbsoluteWslPath(TestDistributions[0])
+  it.each(WslPrefixes)('leaves an already absolute %s UNC path unchanged', (prefix) => {
+    const filePath = createAbsoluteWslPath(prefix, TestDistributions[0])
 
     expect(normalizeWslPath(filePath, 'win32')).toBe(filePath)
   })
@@ -33,7 +38,7 @@ describe('utils/normalizeWslPath', () => {
   })
 
   it('does not change WSL paths on non-Windows platforms', () => {
-    const filePath = createRelativeWslPath(TestDistributions[0])
+    const filePath = createRelativeWslPath(WslPrefixes[0], TestDistributions[0])
 
     expect(normalizeWslPath(filePath, 'linux')).toBe(filePath)
   })

--- a/src/plugins/commander/upload.ts
+++ b/src/plugins/commander/upload.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import fs from 'fs-extra'
 import { isUrl } from '../../utils/common'
+import { normalizeWslPath } from '../../utils/normalizeWslPath'
 import { IPicGo, IPlugin, OutputFormat, IFileUploadProgress, IStringKeyMap } from '../../types'
 import type { ILocalesKey } from '../../i18n/zh-CN'
 import { IBuildInEvent } from '../../utils/enum'
@@ -13,6 +14,11 @@ interface UploadCommandOptions {
 }
 
 const formatMB = (bytes: number): string => (bytes / BYTES_PER_MB).toFixed(1)
+
+const resolveUploadInput = (item: string): string => {
+  const normalizedItem = normalizeWslPath(item)
+  return isUrl(normalizedItem) ? normalizedItem : path.resolve(normalizedItem)
+}
 
 const buildFileUploadArgs = (ctx: IPicGo, payload: IFileUploadProgress): IStringKeyMap<string> => {
   const resumedSuffix = payload.resumed
@@ -47,9 +53,7 @@ const upload: IPlugin = {
       )
       .action(async (input: string[], options: UploadCommandOptions) => {
         const inputList = input
-          .map((item: string) => {
-            return isUrl(item) ? item : path.resolve(item)
-          })
+          .map(resolveUploadInput)
           .filter((item: string) => {
             const exist = fs.existsSync(item) || isUrl(item)
             if (!exist) {
@@ -86,4 +90,4 @@ const upload: IPlugin = {
   }
 }
 
-export { upload }
+export { resolveUploadInput, upload }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -9,6 +9,7 @@ import {
   IPicGo
 } from '../types'
 import { URL } from 'url'
+import { normalizeWslPath } from './normalizeWslPath'
 
 export const isUrl = (url: string): boolean => (url.startsWith('http://') || url.startsWith('https://'))
 
@@ -71,17 +72,19 @@ export const getImageSize = (file: Buffer): IImgSize => {
 }
 
 export const getFSFile = async (filePath: string): Promise<IPathTransformedImgInfo> => {
+  const normalizedFilePath = normalizeWslPath(filePath)
+
   try {
     return {
-      extname: path.extname(filePath),
-      fileName: path.basename(filePath),
-      filePath,
-      buffer: await fs.readFile(filePath),
+      extname: path.extname(normalizedFilePath),
+      fileName: path.basename(normalizedFilePath),
+      filePath: normalizedFilePath,
+      buffer: await fs.readFile(normalizedFilePath),
       success: true
     }
   } catch {
     return {
-      reason: `read file ${filePath} error`,
+      reason: `read file ${normalizedFilePath} error`,
       success: false
     }
   }

--- a/src/utils/normalizeWslPath.ts
+++ b/src/utils/normalizeWslPath.ts
@@ -1,11 +1,12 @@
-const RELATIVE_WSL_PATH = /^wsl\$[\\/]/i
+const RELATIVE_WSL_PATH = /^wsl(?:\$|\.localhost)[\\/]/i
 
 /**
  * Convert the WSL network-share path emitted by some Windows integrations to
  * a UNC path that Node.js can read.
  *
- * Windows exposes WSL files through paths such as `\\\\wsl$\\<distribution>\\...`,
- * while integrations such as Typora may omit the leading UNC separators.
+ * Windows exposes WSL files through paths such as `\\\\wsl$\\<distribution>\\...`
+ * or `\\\\wsl.localhost\\<distribution>\\...`, while integrations such as Typora
+ * may omit the leading UNC separators.
  */
 export const normalizeWslPath = (filePath: string, platform: NodeJS.Platform = process.platform): string => {
   if (platform !== 'win32' || !RELATIVE_WSL_PATH.test(filePath)) {
@@ -13,6 +14,5 @@ export const normalizeWslPath = (filePath: string, platform: NodeJS.Platform = p
   }
 
   const normalizedPath = filePath.replaceAll('/', '\\').replace(/\\+/g, '\\')
-  const relativeWslPath = normalizedPath.replace(/^wsl\$\\+/i, 'wsl$\\')
-  return `\\\\${relativeWslPath}`
+  return `\\\\${normalizedPath}`
 }

--- a/src/utils/normalizeWslPath.ts
+++ b/src/utils/normalizeWslPath.ts
@@ -1,0 +1,18 @@
+const RELATIVE_WSL_PATH = /^wsl\$[\\/]/i
+
+/**
+ * Convert the WSL network-share path emitted by some Windows integrations to
+ * a UNC path that Node.js can read.
+ *
+ * Windows exposes WSL files through paths such as `\\\\wsl$\\<distribution>\\...`,
+ * while integrations such as Typora may omit the leading UNC separators.
+ */
+export const normalizeWslPath = (filePath: string, platform: NodeJS.Platform = process.platform): string => {
+  if (platform !== 'win32' || !RELATIVE_WSL_PATH.test(filePath)) {
+    return filePath
+  }
+
+  const normalizedPath = filePath.replaceAll('/', '\\').replace(/\\+/g, '\\')
+  const relativeWslPath = normalizedPath.replace(/^wsl\$\\+/i, 'wsl$\\')
+  return `\\\\${relativeWslPath}`
+}


### PR DESCRIPTION
## 改动说明

- 在 Windows 上将 Typora 等调用方传入的 wsl$\发行版\... 路径转换为可读取的 UNC 路径。
- 在 PicGo Core 的文件读取入口执行转换，使 GUI、PicGo Server 和 Core API 共用同一修复。
- 保留原始上传输入作为 origin；filePath 使用实际读取的 UNC 路径。
- CLI 在 path.resolve 和文件存在性检查之前完成转换，避免原始 WSL 路径被解析为当前目录下的相对路径。
- 已有 UNC 路径、普通路径以及非 Windows 平台的输入保持不变。

## 单元测试

- normalizeWslPath：覆盖反斜杠、正斜杠、重复分隔符、已有 UNC、普通路径及非 Windows 平台。
- getFSFile：验证文件读取及返回的文件元数据使用规范化后的路径。
- commander upload：验证 CLI 在 path.resolve 前调用路径规范化。

## 集成测试

- 在 src/__tests__/integration/uploadWslPath.spec.ts 中新增真实 WSL 上传测试。
- 测试在 Windows + Ubuntu-22.04 上创建真实 WSL 文件，将未经预处理的 wsl$ 路径直接传给 PicGo Core。
- 验证文件内容、规范化后的 filePath、保留的原始 origin 以及最终上传结果。
- 未检测到 Windows WSL 发行版时自动跳过。

## 验证结果

- 相关测试：3 个单元测试文件和 1 个集成测试文件，共 9 项测试全部通过。
- 全量测试：24 个测试文件，236 项测试全部通过。

关联问题：https://github.com/Molunerfinn/PicGo/issues/1439
迁移来源：https://github.com/Molunerfinn/PicGo/pull/1440